### PR TITLE
handle for status 403 with JurnalApi::Forbidden

### DIFF
--- a/lib/faraday/raise_http_exception.rb
+++ b/lib/faraday/raise_http_exception.rb
@@ -9,6 +9,8 @@ module FaradayMiddleware
         case response[:status].to_i
         when 400
           raise JurnalApi::BadRequest, error_message_400(response)
+        when 403
+          raise JurnalApi::Forbidden.new error_message_400(response), response[:body]
         when 404
           raise JurnalApi::NotFound, error_message_400(response)
         when 409

--- a/lib/jurnal_api/error.rb
+++ b/lib/jurnal_api/error.rb
@@ -14,6 +14,9 @@ module JurnalApi
   # Raised when Jurnal returns the HTTP status code 400
   class BadRequest < Error; end
 
+  # Raised when Jurnal returns the HTTP status code 403
+  class Forbidden < ErrorWithBody; end
+
   # Raised when Jurnal returns the HTTP status code 404
   class NotFound < Error; end
 

--- a/spec/jurnal_api/client/contacts_spec.rb
+++ b/spec/jurnal_api/client/contacts_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe JurnalApi::Client::Contacts do
   let(:client)          { JurnalApi::Client.new(access_token: access_token) }
 
   describe '#contact_create' do
-    context 'successful' do
-      let(:dummy_params) do
-        {
-          person: {
-            display_name: 'Elon Musk',
-            is_customer:  true,
-            people_type:  'customer'
-          }
+    let(:dummy_params) do
+      {
+        person: {
+          display_name: 'Elon Musk',
+          is_customer:  true,
+          people_type:  'customer'
         }
-      end
+      }
+    end
 
+    context 'successful' do
       let(:dummy_response) { read_file_fixture('responses/contacts/create_contact_success_response.json') }
 
       before do
@@ -38,6 +38,31 @@ RSpec.describe JurnalApi::Client::Contacts do
 
       it 'should return a json response' do
         expect(subject).to eq dummy_response
+      end
+    end
+
+    context 'failed with status 403' do
+      let(:dummy_response) do
+        { 'message' => 'Invalid authentication credentials' }
+      end
+
+      before do
+        @expected_stub = 
+          stub_request(:post, "#{module_endpoint}.json")
+            .with(headers: { apikey: access_token }, body: dummy_params.to_json)
+            .to_return(status: 403, body: dummy_response.to_json)
+      end
+
+      subject { client.contact_create(dummy_params.to_json) }
+
+      it 'should raise a specific error' do
+        expect { subject }.to raise_error do |error|
+          expect(error).to          be_a(JurnalApi::Forbidden)
+          expect(error.message).to  eq "POST #{module_endpoint}.json: 403"
+          expect(error.body).to     eq dummy_response
+        end
+
+        expect(@expected_stub).to have_been_requested
       end
     end
   end


### PR DESCRIPTION
1. introduce new error class JurnalApi::Forbidden
2. handle for status 403 with JurnalApi::Forbidden (with body)