### PR TITLE
use faraday middleware json only when response content type is json

### DIFF
--- a/lib/jurnal_api/connection.rb
+++ b/lib/jurnal_api/connection.rb
@@ -23,7 +23,8 @@ module JurnalApi
 
         unless raw
           case format.to_s.downcase
-            when 'json' then connection.use FaradayMiddleware::ParseJson
+            when 'json'
+              connection.use(FaradayMiddleware::ParseJson, :content_type => /\bjson$/)
           end
         end
 


### PR DESCRIPTION
ref: https://github.com/lostisland/faraday_middleware/issues/73#issuecomment-25672028
internal error: https://pt-jurnal-consulting-indonesia.sentry.io/issues/4182852307/?project=5414416&referrer=jira_integration

use faraday middleware json only when response content type is json
cause when status 503, the response header is "text/plain" even the request header is "application/json"

<img width="769" alt="Screenshot 2023-07-04 at 23 10 17" src="https://github.com/mekari-engineering/ruby-jurnal-client/assets/45851317/3467e1f7-ad46-4e41-8af3-11cac29a349e">
<img width="759" alt="Screenshot 2023-07-04 at 23 10 00" src="https://github.com/mekari-engineering/ruby-jurnal-client/assets/45851317/78babfcf-f96a-4a19-b9a6-374e1b8a6d67">
