### PR TITLE
add bank_partner endpoint as bank_partners

### DIFF
--- a/lib/jurnal_api/client.rb
+++ b/lib/jurnal_api/client.rb
@@ -3,6 +3,7 @@ module JurnalApi
   class Client < API
     Dir[File.expand_path('../client/*.rb', __FILE__)].each{|f| require f}
 
+    include JurnalApi::Client::Bank
     include JurnalApi::Client::BankTransfer
     include JurnalApi::Client::Customers
     include JurnalApi::Client::JournalEntries

--- a/lib/jurnal_api/client/bank.rb
+++ b/lib/jurnal_api/client/bank.rb
@@ -2,8 +2,8 @@ module JurnalApi
   class Client
     # Defines methods related to Bank
     module Bank
-      def bank_partners(params = {})
-        get('bank_partner', params)
+      def bank_partners()
+        get('bank_partner')
       end
     end
   end

--- a/lib/jurnal_api/client/bank.rb
+++ b/lib/jurnal_api/client/bank.rb
@@ -1,0 +1,10 @@
+module JurnalApi
+  class Client
+    # Defines methods related to Bank
+    module Bank
+      def bank_partners(params = {})
+        get('bank_partner', params)
+      end
+    end
+  end
+end

--- a/spec/fixtures/responses/bank/bank_partner_response.json
+++ b/spec/fixtures/responses/bank/bank_partner_response.json
@@ -1,0 +1,24 @@
+{
+  "banks": [
+    {
+        "id": 1,
+        "name": "PT. BANK CENTRAL ASIA TBK.",
+        "created_at": "2016-10-21T06:05:38.000Z",
+        "updated_at": "2022-11-30T09:11:47.000Z",
+        "use_for_direct_feed": true,
+        "use_for_bank_account": true,
+        "use_for_transfer": false,
+        "auto_confirm": true
+    },
+    {
+        "id": 2,
+        "name": "BCA Personal",
+        "created_at": "2016-10-21T06:05:38.000Z",
+        "updated_at": "2016-10-21T06:05:38.000Z",
+        "use_for_direct_feed": true,
+        "use_for_bank_account": true,
+        "use_for_transfer": false,
+        "auto_confirm": false
+    }
+  ]
+}

--- a/spec/jurnal_api/client/bank_spec.rb
+++ b/spec/jurnal_api/client/bank_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe JurnalApi::Client::SalesInvoices do
+  let(:client) { JurnalApi::Client.new }
+  let(:module_endpoint) { 'https://sandbox-api.jurnal.id/core/api/v1/' }
+
+  describe '#bank_spec' do
+    let(:dummy_response) do
+      read_file_fixture('responses/bank/bank_partner_response.json')
+    end
+
+    before do
+      expected_url = module_endpoint + 'bank_partner.json'
+
+      @expected_stub =
+        stub_request(:get, expected_url)
+        .to_return(status: 200, body: dummy_response.to_json, headers: header_json)
+    end
+
+    subject { client.bank_partners() }
+
+    it 'should hit the expected stub' do
+      subject
+
+      expect(@expected_stub).to have_been_requested
+    end
+
+    it 'should return a json response' do
+      expect(subject).to eq dummy_response
+    end
+  end
+end


### PR DESCRIPTION
add `bank_partner` endpoint to `get bank_partner_id` related to create contact from this endpoint : 
https://jurnal-mekari.stoplight.io/docs/jurnal-api/35fe4ffdd991b-get-bank-partners
